### PR TITLE
Use slightly more standard Unix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ start: prepublish
 	http-server
 
 index.html: Readme.md head.html foot.html package.json Makefile
-	cat head.html > build.html
+	cp head.html build.html
 	## Change <project name> to This
-	sed 's/&lt;project name&gt;/This/g' Readme.md >> build.md
+	sed 's/&lt;project name&gt;/This/g' Readme.md > build.md
 	marked -i build.md >> build.html
 	rm build.md
 	cat foot.html >> build.html


### PR DESCRIPTION
I think this is more standard and makes what's going on clearer, but feel free to reject.

Note in particular that `build.md` is always truncated instead of appended to, which matters if `marked` causes the build to failed (and `rm build.md` isn't run).