### PR TITLE
Add "don't break the test suite" to rules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ There are a few basic ground-rules for contributors:
 1. **External API changes and significant modifications** ought to be subject to an **internal pull-request** to solicit feedback from other contributors.
 1. Internal pull-requests to solicit feedback are *encouraged* for any other non-trivial contribution but left to the discretion of the contributor.
 1. Contributors should attempt to adhere to the prevailing code-style.
+1. Don't break the test suite or CI build if the project has one.
 
 ## Releases
 


### PR DESCRIPTION
Seems pretty obvious why this is important but is probably worth calling out specifically for new contributors to keep in mind. (I like how this also kind of implies that if they break the build, it's their responsibility to fix it, because they've violated a rule.)